### PR TITLE
Nested directory reading

### DIFF
--- a/python/test/test_readers.py
+++ b/python/test/test_readers.py
@@ -1,7 +1,31 @@
+import os
+import shutil
+import tempfile
 import unittest
-from nose.tools import assert_raises
+from nose.tools import assert_equal, assert_raises
 
-from thunder.rdds.fileio.readers import LocalFSFileReader, FileNotFoundError
+from thunder.rdds.fileio.readers import LocalFSFileReader, LocalFSParallelReader, FileNotFoundError
+
+
+def touch_empty(filepath):
+    if not os.path.exists(filepath):
+        dirname, filename = os.path.split(filepath)
+        if not os.path.isdir(dirname):
+            os.mkdir(dirname)
+        fp = open(filepath, 'w')
+        fp.close()
+    else:
+        os.utime(filepath, None)
+
+
+class TestCaseWithOutputDir(unittest.TestCase):
+    def setUp(self):
+        super(TestCaseWithOutputDir, self).setUp()
+        self.outputdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        super(TestCaseWithOutputDir, self).tearDown()
+        shutil.rmtree(self.outputdir)
 
 
 class TestLocalReader(unittest.TestCase):
@@ -9,3 +33,40 @@ class TestLocalReader(unittest.TestCase):
     def test_readRaisesFileNotFoundError(self):
         reader = LocalFSFileReader()
         assert_raises(FileNotFoundError, reader.read, "this directory doesnt exist", "definitely not with this file")
+
+
+class TestLocalFileListing(TestCaseWithOutputDir):
+
+    def _run_tst(self, filenames, recursive=False, expected=None):
+        if expected:
+            basenames = expected
+        else:
+            basenames = filenames
+        expected = [os.path.join(self.outputdir, fname) for fname in basenames]
+        del basenames
+
+        inputFilepaths = [os.path.join(self.outputdir, fname) for fname in filenames]
+        for fname in inputFilepaths:
+            touch_empty(fname)
+
+        reader = LocalFSParallelReader(None)
+        actual = reader.listFiles(self.outputdir, recursive=recursive)
+        assert_equal(sorted(expected), actual)
+
+    def test_flatDirRecursive(self):
+        filenames = ["b", "a", "c"]
+        self._run_tst(filenames, True)
+
+    def test_flatDir(self):
+        filenames = ["b", "a", "c"]
+        self._run_tst(filenames, False)
+
+    def test_nestedDirRecursive(self):
+        filenames = ["foo/b", "foo/bar/q", "bar/a", "c"]
+        self._run_tst(filenames, True)
+
+    def test_nestedDir(self):
+        filenames = ["foo/b", "foo/bar/q", "bar/a", "c"]
+        self._run_tst(filenames, False, expected=["c"])
+
+

--- a/python/test/test_readers.py
+++ b/python/test/test_readers.py
@@ -37,7 +37,7 @@ class TestLocalReader(unittest.TestCase):
 
 class TestLocalFileListing(TestCaseWithOutputDir):
 
-    def _run_tst(self, filenames, recursive=False, expected=None):
+    def _setup_files(self, filenames, expected=None):
         if expected:
             basenames = expected
         else:
@@ -48,25 +48,51 @@ class TestLocalFileListing(TestCaseWithOutputDir):
         inputFilepaths = [os.path.join(self.outputdir, fname) for fname in filenames]
         for fname in inputFilepaths:
             touch_empty(fname)
+        return expected
+
+    def _run_parallelReader_tst(self, filenames, recursive=False, expected=None):
+        expected = self._setup_files(filenames, expected=expected)
 
         reader = LocalFSParallelReader(None)
         actual = reader.listFiles(self.outputdir, recursive=recursive)
         assert_equal(sorted(expected), actual)
 
-    def test_flatDirRecursive(self):
+    def _run_localReader_tst(self,  filenames, recursive=False, expected=None):
+        expected = self._setup_files(filenames, expected=expected)
+        reader = LocalFSFileReader()
+        actual = reader.list(self.outputdir, recursive=recursive)
+        assert_equal(sorted(expected), actual)
+
+    def test_flatDirParallelRecursive(self):
         filenames = ["b", "a", "c"]
-        self._run_tst(filenames, True)
+        self._run_parallelReader_tst(filenames, True)
 
-    def test_flatDir(self):
+    def test_flatDirLocalRecursive(self):
         filenames = ["b", "a", "c"]
-        self._run_tst(filenames, False)
+        self._run_localReader_tst(filenames, True)
 
-    def test_nestedDirRecursive(self):
-        filenames = ["foo/b", "foo/bar/q", "bar/a", "c"]
-        self._run_tst(filenames, True)
+    def test_flatDirParallel(self):
+        filenames = ["b", "a", "c"]
+        self._run_parallelReader_tst(filenames, False)
 
-    def test_nestedDir(self):
+    def test_flatDirLocal(self):
+        filenames = ["b", "a", "c"]
+        self._run_localReader_tst(filenames, False)
+
+    def test_nestedDirParallelRecursive(self):
         filenames = ["foo/b", "foo/bar/q", "bar/a", "c"]
-        self._run_tst(filenames, False, expected=["c"])
+        self._run_parallelReader_tst(filenames, True)
+
+    def test_nestedDirLocalRecursive(self):
+        filenames = ["foo/b", "foo/bar/q", "bar/a", "c"]
+        self._run_localReader_tst(filenames, True)
+
+    def test_nestedDirParallel(self):
+        filenames = ["foo/b", "foo/bar/q", "bar/a", "c"]
+        self._run_parallelReader_tst(filenames, False, expected=["c"])
+
+    def test_nestedDirLocal(self):
+        filenames = ["foo/b", "foo/bar/q", "bar/a", "c"]
+        self._run_localReader_tst(filenames, False, expected=["c"])
 
 

--- a/python/thunder/rdds/fileio/imagesloader.py
+++ b/python/thunder/rdds/fileio/imagesloader.py
@@ -46,7 +46,7 @@ class ImagesLoader(object):
         return Images(self.sc.parallelize(enumerate(arrays), len(arrays)),
                       dims=shape, dtype=str(dtype), nimages=len(arrays))
 
-    def fromStack(self, datapath, dims, dtype='int16', ext='stack', startidx=None, stopidx=None):
+    def fromStack(self, datapath, dims, dtype='int16', ext='stack', startidx=None, stopidx=None, recursive=False):
         """Load an Images object stored in a directory of flat binary files
 
         The RDD wrapped by the returned Images object will have a number of partitions equal to the number of image data
@@ -71,6 +71,11 @@ class ImagesLoader(object):
         startidx, stopidx: nonnegative int. optional.
             Indices of the first and last-plus-one data file to load, relative to the sorted filenames matching
             `datapath` and `ext`. Interpreted according to python slice indexing conventions.
+
+        recursive: boolean, default False
+            If true, will recursively descend directories rooted at datapath, loading all files in the tree that
+            have an extension matching 'ext'. Recursive loading is currently only implemented for local filesystems
+            (not s3).
         """
         if not dims:
             raise ValueError("Image dimensions must be specified if loading from binary stack data")
@@ -79,11 +84,11 @@ class ImagesLoader(object):
             return frombuffer(buf, dtype=dtype, count=int(prod(dims))).reshape(dims, order='F')
 
         reader = getParallelReaderForPath(datapath)(self.sc)
-        readerrdd = reader.read(datapath, ext=ext, startidx=startidx, stopidx=stopidx)
+        readerrdd = reader.read(datapath, ext=ext, startidx=startidx, stopidx=stopidx, recursive=recursive)
         return Images(readerrdd.mapValues(toArray), nimages=reader.lastnrecs, dims=dims,
                       dtype=dtype)
 
-    def fromTif(self, datapath, ext='tif', startidx=None, stopidx=None):
+    def fromTif(self, datapath, ext='tif', startidx=None, stopidx=None, recursive=False):
         """Load an Images object stored in a directory of (single-page) tif files
 
         The RDD wrapped by the returned Images object will have a number of partitions equal to the number of image data
@@ -102,16 +107,21 @@ class ImagesLoader(object):
         startidx, stopidx: nonnegative int. optional.
             Indices of the first and last-plus-one data file to load, relative to the sorted filenames matching
             `datapath` and `ext`. Interpreted according to python slice indexing conventions.
+
+        recursive: boolean, default False
+            If true, will recursively descend directories rooted at datapath, loading all files in the tree that
+            have an extension matching 'ext'. Recursive loading is currently only implemented for local filesystems
+            (not s3).
         """
         def readTifFromBuf(buf):
             fbuf = BytesIO(buf)
             return imread(fbuf, format='tif')
 
         reader = getParallelReaderForPath(datapath)(self.sc)
-        readerrdd = reader.read(datapath, ext=ext, startidx=startidx, stopidx=stopidx)
+        readerrdd = reader.read(datapath, ext=ext, startidx=startidx, stopidx=stopidx, recursive=recursive)
         return Images(readerrdd.mapValues(readTifFromBuf), nimages=reader.lastnrecs)
 
-    def fromMultipageTif(self, datafile, ext='tif', startidx=None, stopidx=None):
+    def fromMultipageTif(self, datafile, ext='tif', startidx=None, stopidx=None, recursive=False):
         """Sets up a new Images object with data to be read from one or more multi-page tif files.
 
         The RDD underlying the returned Images will have key, value data as follows:
@@ -150,10 +160,10 @@ class ImagesLoader(object):
             return dstack(imgarys)
 
         reader = getParallelReaderForPath(datafile)(self.sc)
-        readerrdd = reader.read(datafile, ext=ext, startidx=startidx, stopidx=stopidx)
+        readerrdd = reader.read(datafile, ext=ext, startidx=startidx, stopidx=stopidx, recursive=recursive)
         return Images(readerrdd.mapValues(multitifReader), nimages=reader.lastnrecs)
 
-    def fromPng(self, datafile, ext='png', startidx=None, stopidx=None):
+    def fromPng(self, datafile, ext='png', startidx=None, stopidx=None, recursive=False):
         """Load an Images object stored in a directory of png files
 
         The RDD wrapped by the returned Images object will have a number of partitions equal to the number of image data
@@ -172,11 +182,16 @@ class ImagesLoader(object):
         startidx, stopidx: nonnegative int. optional.
             Indices of the first and last-plus-one data file to load, relative to the sorted filenames matching
             `datapath` and `ext`. Interpreted according to python slice indexing conventions.
+
+        recursive: boolean, default False
+            If true, will recursively descend directories rooted at datapath, loading all files in the tree that
+            have an extension matching 'ext'. Recursive loading is currently only implemented for local filesystems
+            (not s3).
         """
         def readPngFromBuf(buf):
             fbuf = BytesIO(buf)
             return imread(fbuf, format='png')
 
         reader = getParallelReaderForPath(datafile)(self.sc)
-        readerrdd = reader.read(datafile, ext=ext, startidx=startidx, stopidx=stopidx)
+        readerrdd = reader.read(datafile, ext=ext, startidx=startidx, stopidx=stopidx, recursive=recursive)
         return Images(readerrdd.mapValues(readPngFromBuf), nimages=reader.lastnrecs)

--- a/python/thunder/utils/common.py
+++ b/python/thunder/utils/common.py
@@ -107,7 +107,7 @@ def raiseErrorIfPathExists(path):
     # check that specified output path does not already exist
     from thunder.rdds.fileio.readers import getFileReaderForPath
     reader = getFileReaderForPath(path)()
-    existing = reader.list(path)
+    existing = reader.list(path, includeDirectories=True)
     if existing:
         raise ValueError("Path %s appears to already exist. Specify a new directory, or call " % path +
                          "with overwrite=True to overwrite.")

--- a/python/thunder/utils/context.py
+++ b/python/thunder/utils/context.py
@@ -266,17 +266,15 @@ class ThunderContext():
             return images.toBlocks(blockSize, units=blockSizeUnits).toSeries()
 
         else:
-            if recursive:
-                raise NotImplementedError("Recursive loading is currently only implemented with shuffle=True - sorry!")
             from thunder.rdds.fileio.seriesloader import SeriesLoader
             loader = SeriesLoader(self._sc)
             if inputformat.lower() == 'stack':
                 return loader.fromStack(datapath, dims, datatype=dtype, blockSize=blockSize,
-                                        startidx=startidx, stopidx=stopidx)
+                                        startidx=startidx, stopidx=stopidx, recursive=recursive)
             else:
                 # tif stack
                 return loader.fromMultipageTif(datapath, blockSize=blockSize,
-                                               startidx=startidx, stopidx=stopidx)
+                                               startidx=startidx, stopidx=stopidx, recursive=recursive)
 
     def convertImagesToSeries(self, datapath, outputdirpath, dims=None, inputformat='stack',
                               dtype='int16', blocksize="150M", blockSizeUnits="pixels", startidx=None, stopidx=None,
@@ -393,16 +391,16 @@ class ThunderContext():
 
             images.toBlocks(blocksize, units=blockSizeUnits).saveAsBinarySeries(outputdirpath, overwrite=overwrite)
         else:
-            if recursive:
-                raise NotImplementedError("Recursive loading is currently only implemented with shuffle=True - sorry!")
             from thunder.rdds.fileio.seriesloader import SeriesLoader
             loader = SeriesLoader(self._sc)
             if inputformat.lower() == 'stack':
                 loader.saveFromStack(datapath, outputdirpath, dims, datatype=dtype,
-                                     blockSize=blocksize, overwrite=overwrite, startidx=startidx, stopidx=stopidx)
+                                     blockSize=blocksize, overwrite=overwrite, startidx=startidx,
+                                     stopidx=stopidx, recursive=recursive)
             else:
                 loader.saveFromMultipageTif(datapath, outputdirpath, blockSize=blocksize,
-                                            startidx=startidx, stopidx=stopidx, overwrite=overwrite)
+                                            startidx=startidx, stopidx=stopidx, overwrite=overwrite,
+                                            recursive=recursive)
 
     def makeExample(self, dataset, **opts):
         """


### PR DESCRIPTION
This PR adds a 'recursive' keyword to all the image data input methods (basically, any time tifs or binary stacks are loaded from disk). If `recursive==True`, then the read methods will descend through a directory tree rooted at the passed `datapath` path, and try to load all files found in that tree with the specified file extension.

* This only works for reading from the local file system - specifying `recursive=True` when reading from S3 will result in an apologetic `NotImplementedError`.
* It also exposes an `ext` (extension) keyword argument on the `ThunderContext` object, allowing non-standard file extensions to be easily specified. Previously, to load flat binary image stacks with any extension other than "stack" (such as "bin"), one would have to manually create an ImagesLoader and specify the `ext` keyword there. Now .bin binary files can be read at the context level with just an additional keyword.
* This PR also makes file listing behavior a little more consistent between the local and parallel reader implementations, as well as between the BotoS3 and LocalFS readers. It is still not a perfect match, but now at least there are consistent `list()` methods on the local file readers, and `listFiles()` methods on the parallel readers. The main remaining differences are that the local (not parallel) readers are expected to be able to handle wildcard characters in the path specifier, while the parallel readers don't handle general wildcards, only allowing an optional extension to be specified. Also the BotoS3 readers do not support recursive listing of files, due mainly to the absence of an easy equivalent to `os.walk` in the boto API. 

(Just discovered a failing unit test as a result of this change - have pushed a commit to fix, but am not sure whether that will be picked up in the initial PR or no)