### PR TITLE
add back pil_to_array function for use with old versions of PIL

### DIFF
--- a/python/thunder/utils/common.py
+++ b/python/thunder/utils/common.py
@@ -69,6 +69,85 @@ def smallest_float_type(dtype):
     return promote_types(intype, comptype)
 
 
+def pil_to_array(pilImage):
+    """
+    Load a PIL image and return it as a numpy array.  Only supports greyscale images;
+    the return value will be an M x N array.
+
+    Adapted from matplotlib's pil_to_array, copyright 2009-2012 by John D Hunter
+    """
+    # This is intended to be used only with older versions of PIL, for which the new-style
+    # way of getting a numpy array (np.array(pilimg)) does not appear to work in all cases.
+    # np.array(pilimg) appears to work with Pillow 2.3.0; with PIL 1.1.7 it leads to
+    # errors similar to the following:
+    # In [15]: data = tsc.loadImages('/path/to/tifs/', inputformat='tif-stack')
+    # In [16]: data.first()[1].shape
+    # Out[16]: (1, 1, 1)
+    # In [17]: data.first()[1]
+    # Out[17]: array([[[ <PIL.TiffImagePlugin.TiffImageFile image mode=I;16 size=512x512 at 0x3B02B00>]]],
+    # dtype=object)
+    def toarray(im_, dtype):
+        """Return a 1D array of dtype."""
+        from numpy import fromstring
+        # Pillow wants us to use "tobytes"
+        if hasattr(im_, 'tobytes'):
+               x_str = im_.tobytes('raw', im_.mode)
+        else:
+            x_str = im_.tostring('raw', im_.mode)
+        x_ = fromstring(x_str, dtype)
+        return x_
+    if pilImage.mode in ('RGBA', 'RGBX', 'RGB'):
+        raise ValueError("Thunder only supports luminance / greyscale images in pil_to_array; got image mode: '%s'" %
+                         pilImage.mode)
+    if pilImage.mode == 'L':
+        im = pilImage  # no need to luminance images
+        # return MxN luminance array
+        x = toarray(im, 'uint8')
+        x.shape = im.size[1], im.size[0]
+        return x
+    elif pilImage.mode.startswith('I;16'):
+        # return MxN luminance array of uint16
+        im = pilImage
+        if im.mode.endswith('B'):
+            x = toarray(im, '>u2')
+        else:
+            x = toarray(im, '<u2')
+        x.shape = im.size[1], im.size[0]
+        return x.astype('=u2')
+    elif pilImage.mode.startswith('I;32') or pilImage.mode == 'I':
+        # default 'I' mode is 32 bit; see http://svn.effbot.org/public/tags/pil-1.1.7/libImaging/Unpack.c (at bottom)
+        # return MxN luminance array of uint32
+        im = pilImage
+        if im.mode.endswith('B'):
+            x = toarray(im, '>u4')
+        else:
+            x = toarray(im, '<u4')
+        x.shape = im.size[1], im.size[0]
+        return x.astype('=u4')
+    elif pilImage.mode.startswith('F;16'):
+        # return MxN luminance array of float16
+        im = pilImage
+        if im.mode.endswith('B'):
+            x = toarray(im, '>f2')
+        else:
+            x = toarray(im, '<f2')
+        x.shape = im.size[1], im.size[0]
+        return x.astype('=f2')
+    elif pilImage.mode.startswith('F;32') or pilImage.mode == 'F':
+        # default 'F' mode is 32 bit; see http://svn.effbot.org/public/tags/pil-1.1.7/libImaging/Unpack.c (at bottom)
+        # return MxN luminance array of float32
+        im = pilImage
+        if im.mode.endswith('B'):
+            x = toarray(im, '>f4')
+        else:
+            x = toarray(im, '<f4')
+        x.shape = im.size[1], im.size[0]
+        return x.astype('=f4')
+    else:  # try to convert to an rgba image
+        raise ValueError("Thunder only supports luminance / greyscale images in pil_to_array; got unknown image " +
+                         "mode: '%s'" % pilImage.mode)
+
+
 def parseMemoryString(memstr):
     """Returns the size in bytes of memory represented by a Java-style 'memory string'
 


### PR DESCRIPTION
Old PIL does not load images correctly in Spark using the new-style `array(pilimg)` syntax, however the new pillow module appears to handle this correctly. Here fall back to matplotlib's old `pil_to_array` conversion if we detect that we've got PIL but not pillow installed.

Without this PR, loading tifs (at least single-page tifs, possibly others) with PIL 1.1.7 leads to results like the following:
```python
In [15]: data = tsc.loadImages('/path/to/tifs/', inputformat='tif-stack')
In [16]: data.first()[1].shape
Out[16]: (1, 1, 1)
In [17]: data.first()[1]
Out[17]: array([[[ <PIL.TiffImagePlugin.TiffImageFile image mode=I;16 size=512x512 at 0x3B02B00>]]], dtype=object)
```