### PR TITLE
Windowed normalize optimization

### DIFF
--- a/python/test/test_timeseries.py
+++ b/python/test/test_timeseries.py
@@ -97,6 +97,22 @@ class TestTimeSeriesMethods(TimeSeriesTestCase):
         result_true = (y - b_true) / (b_true + 0.1)
         assert(allclose(vals, result_true, atol=1e-3))
 
+        out = data.normalize('window-fast', window=2)
+        assert_equals('float16', str(out._dtype))
+        vals = out.first()[1]
+        assert_equals('float64', str(vals.dtype))
+        b_true = array([1.0, 2.0, 3.0, 4.0, 5.0])
+        result_true = (y - b_true) / (b_true + 0.1)
+        assert(allclose(vals, result_true, atol=1e-3))
+
+        out = data.normalize('window-fast', window=5)
+        vals = out.first()[1]
+        b_true = array([1.5, 1.5, 2, 3, 4])
+        result_true = (y - b_true) / (b_true + 0.1)
+        assert(allclose(vals, result_true, atol=1e-3))
+
+        
+
     def test_normalization_bymean(self):
         rdd = self.sc.parallelize([(0, array([1, 2, 3, 4, 5], dtype='float16'))])
         data = TimeSeries(rdd, dtype='float16')

--- a/python/thunder/rdds/timeseries.py
+++ b/python/thunder/rdds/timeseries.py
@@ -304,11 +304,14 @@ class TimeSeries(Series):
                 left, right = (window/2 - 1, window/2)
 
             n = len(self.index)
-            ind_perc = round((window-1)*(perc/100)) 
+            ind_perc = round((window-1)*(perc/100.0)) 
             
             def basefunc(x):
                 left_pad = mean(x[:right])
-                right_pad = mean(x[-left:])
+                if left != 0:
+                    right_pad = mean(x[-left:])
+                else:
+                    right_pad = x[-1]
                 y = concatenate([ left_pad*ones(left), x, right_pad*ones(right) ])  
                 return asarray([sort(y[i-left:i+right+1])[ind_perc] for i in xrange(left,len(x)+left)])
 

--- a/python/thunder/rdds/timeseries.py
+++ b/python/thunder/rdds/timeseries.py
@@ -1,6 +1,6 @@
 from numpy import sqrt, pi, angle, fft, fix, zeros, roll, dot, mean, \
     array, size, diag, tile, ones, asarray, polyfit, polyval, arange, \
-    percentile, ceil, round, sort, ones
+    percentile, ceil, round, sort, ones, concatenate
 
 from thunder.rdds.series import Series
 from thunder.utils.common import loadmatvar, checkparams
@@ -309,7 +309,7 @@ class TimeSeries(Series):
             def basefunc(x):
                 left_pad = mean(x[:right])
                 right_pad = mean(x[-left:])
-                y = concatenate([ left_pad*np.ones(left), x, right_pad*ones(right) ])  
+                y = concatenate([ left_pad*ones(left), x, right_pad*ones(right) ])  
                 return asarray([sort(y[i-left:i+right+1])[ind_perc] for i in xrange(left,len(x)+left)])
 
         def get(y):

--- a/python/thunder/rdds/timeseries.py
+++ b/python/thunder/rdds/timeseries.py
@@ -1,6 +1,6 @@
 from numpy import sqrt, pi, angle, fft, fix, zeros, roll, dot, mean, \
     array, size, diag, tile, ones, asarray, polyfit, polyval, arange, \
-    percentile, ceil
+    percentile, ceil, round, sort, ones
 
 from thunder.rdds.series import Series
 from thunder.utils.common import loadmatvar, checkparams
@@ -266,19 +266,19 @@ class TimeSeries(Series):
         Parameters
         ----------
         baseline : str, optional, default = 'percentile'
-            Quantity to use as the baseline, options are 'mean', 'percentile', or 'window'
+            Quantity to use as the baseline, options are 'mean', 'percentile', 'window', or 'window-fast'
 
         perc : int, optional, default = 20
-            Percentile value to use, for 'percentile' or 'window' baseline only
+            Percentile value to use, for 'percentile', 'window', or 'window-fast' baseline only
 
         window : int, optional, default = 6
-            Size of window for baseline estimation, for 'window' baseline only
+            Size of window for baseline estimation, for 'window' and 'window-fast' baseline only
         """
-        checkparams(baseline, ['mean', 'percentile', 'window'])
+        checkparams(baseline, ['mean', 'percentile', 'window', 'window-fast'])
         method = baseline.lower()
     
         from warnings import warn
-        if method is not 'window' and window is not None:
+        if not (method == 'window' or method == 'window-fast') and window is not None:
             warn('Setting window without using method "window" has no effect')
 
         if method == 'mean':
@@ -287,7 +287,6 @@ class TimeSeries(Series):
         if method == 'percentile':
             basefunc = lambda x: percentile(x, perc)
 
-        # TODO optimize implementation by doing a single initial sort
         if method == 'window':
             if window & 0x1:
                 left, right = (ceil(window/2), ceil(window/2) + 1)
@@ -297,6 +296,21 @@ class TimeSeries(Series):
             n = len(self.index)
             basefunc = lambda x: asarray([percentile(x[max(ix-left, 0):min(ix+right+1, n)], perc)
                                           for ix in arange(0, n)])
+
+        if method == 'window-fast':
+            if window%2:
+                left, right = ((window-1)/2, (window-1)/2)
+            else:
+                left, right = (window/2 - 1, window/2)
+
+            n = len(self.index)
+            ind_perc = round((window-1)*(perc/100)) 
+            
+            def basefunc(x):
+                left_pad = mean(x[:right])
+                right_pad = mean(x[-left:])
+                y = concatenate([ left_pad*np.ones(left), x, right_pad*ones(right) ])  
+                return asarray([sort(y[i-left:i+right+1])[ind_perc] for i in xrange(left,len(x)+left)])
 
         def get(y):
             b = basefunc(y)

--- a/python/thunder/rdds/timeseries.py
+++ b/python/thunder/rdds/timeseries.py
@@ -1,6 +1,6 @@
 from numpy import sqrt, pi, angle, fft, fix, zeros, roll, dot, mean, \
     array, size, diag, tile, ones, asarray, polyfit, polyval, arange, \
-    percentile, ceil, round, sort, ones, concatenate
+    percentile, ceil, round, sort, concatenate
 
 from thunder.rdds.series import Series
 from thunder.utils.common import loadmatvar, checkparams
@@ -298,22 +298,22 @@ class TimeSeries(Series):
                                           for ix in arange(0, n)])
 
         if method == 'window-fast':
-            if window%2:
+            if window % 2:
                 left, right = ((window-1)/2, (window-1)/2)
             else:
                 left, right = (window/2 - 1, window/2)
 
             n = len(self.index)
-            ind_perc = round((window-1)*(perc/100.0)) 
+            indPerc = round((window-1)*(perc/100.0))
             
             def basefunc(x):
-                left_pad = mean(x[:right])
+                leftPad = mean(x[:right])
                 if left != 0:
-                    right_pad = mean(x[-left:])
+                    rightPad = mean(x[-left:])
                 else:
-                    right_pad = x[-1]
-                y = concatenate([ left_pad*ones(left), x, right_pad*ones(right) ])  
-                return asarray([sort(y[i-left:i+right+1])[ind_perc] for i in xrange(left,len(x)+left)])
+                    rightPad = x[-1]
+                y = concatenate([leftPad*ones(left), x, rightPad*ones(right)])
+                return asarray([sort(y[i-left:i+right+1])[indPerc] for i in xrange(left, len(x)+left)])
 
         def get(y):
             b = basefunc(y)


### PR DESCRIPTION
Added a new option -- 'window-fast' -- to TimeSeries.normalize()
This is similar to the 'window' option, except that interpolation during the percentile computation is avoided by no using the numpy.percentile() method. Instead, the index within the window that is closest to the desired percentile is computed ahead of time. Then each window is sorted and this index is retrieved. Also updated the warning message for when widow size is set but user is not using one of the two windowed methods.