### PR TITLE
Faster windowed normalization

### DIFF
--- a/python/test/test_timeseries.py
+++ b/python/test/test_timeseries.py
@@ -101,13 +101,13 @@ class TestTimeSeriesMethods(TimeSeriesTestCase):
         assert_equals('float16', str(out._dtype))
         vals = out.first()[1]
         assert_equals('float64', str(vals.dtype))
-        b_true = array([1.0, 2.0, 3.0, 4.0, 5.0])
+        b_true = array([1, 1, 2, 3, 4])
         result_true = (y - b_true) / (b_true + 0.1)
         assert(allclose(vals, result_true, atol=1e-3))
 
         out = data.normalize('window-fast', window=5)
         vals = out.first()[1]
-        b_true = array([1.5, 1.5, 2, 3, 4])
+        b_true = array([1, 1, 2, 3, 4])
         result_true = (y - b_true) / (b_true + 0.1)
         assert(allclose(vals, result_true, atol=1e-3))
 

--- a/python/thunder/rdds/timeseries.py
+++ b/python/thunder/rdds/timeseries.py
@@ -1,7 +1,6 @@
 from numpy import sqrt, pi, angle, fft, fix, zeros, roll, dot, mean, \
     array, size, diag, tile, ones, asarray, polyfit, polyval, arange, \
     percentile, ceil, float64
-from scipy.ndimage.filters import percentile_filter
 
 from thunder.rdds.series import Series
 from thunder.utils.common import loadmatvar, checkparams
@@ -299,8 +298,8 @@ class TimeSeries(Series):
                                           for ix in arange(0, n)])
 
         if method == 'window-fast':
-            def basefunc(x):
-                return percentile_filter(x.astype(float64), perc, window, mode='nearest')
+            from scipy.ndimage.filters import percentile_filter
+            basefunc = lambda x: percentile_filter(x.astype(float64), perc, window, mode='nearest')
 
         def get(y):
             b = basefunc(y)

--- a/python/thunder/rdds/timeseries.py
+++ b/python/thunder/rdds/timeseries.py
@@ -268,11 +268,11 @@ class TimeSeries(Series):
         baseline : str, optional, default = 'percentile'
             Quantity to use as the baseline, options are 'mean', 'percentile', 'window', or 'window-fast'
 
-        perc : int, optional, default = 20
-            Percentile value to use, for 'percentile', 'window', or 'window-fast' baseline only
-
         window : int, optional, default = 6
             Size of window for baseline estimation, for 'window' and 'window-fast' baseline only
+
+        perc : int, optional, default = 20
+            Percentile value to use, for 'percentile', 'window', or 'window-fast' baseline only
         """
         checkparams(baseline, ['mean', 'percentile', 'window', 'window-fast'])
         method = baseline.lower()

--- a/python/thunder/rdds/timeseries.py
+++ b/python/thunder/rdds/timeseries.py
@@ -1,6 +1,7 @@
 from numpy import sqrt, pi, angle, fft, fix, zeros, roll, dot, mean, \
     array, size, diag, tile, ones, asarray, polyfit, polyval, arange, \
-    percentile, ceil, round, sort, concatenate
+    percentile, ceil, float64
+from scipy.ndimage.filters import percentile_filter
 
 from thunder.rdds.series import Series
 from thunder.utils.common import loadmatvar, checkparams
@@ -298,22 +299,8 @@ class TimeSeries(Series):
                                           for ix in arange(0, n)])
 
         if method == 'window-fast':
-            if window % 2:
-                left, right = ((window-1)/2, (window-1)/2)
-            else:
-                left, right = (window/2 - 1, window/2)
-
-            n = len(self.index)
-            indPerc = round((window-1)*(perc/100.0))
-            
             def basefunc(x):
-                leftPad = mean(x[:right])
-                if left != 0:
-                    rightPad = mean(x[-left:])
-                else:
-                    rightPad = x[-1]
-                y = concatenate([leftPad*ones(left), x, rightPad*ones(right)])
-                return asarray([sort(y[i-left:i+right+1])[indPerc] for i in xrange(left, len(x)+left)])
+                return percentile_filter(x.astype(float64), perc, window, mode='nearest')
 
         def get(y):
             b = basefunc(y)


### PR DESCRIPTION
Speeds up the window-fast option just added in #83 using `scipy.ndimage.filters.percentile_filter`. 

I compared the windowed normalization techniques using a timeseries of length 50,000 and a window of 1,000:
````
window: 4.05s
window-fast-old: 2.64s
window-fast-new: 785ms
```
So we get a speedup of around 3x over the `window-fast` method in #83, and 5x over the original `window` method. These speedups were about the same over other window lengths (50, 500, 5000). 